### PR TITLE
Add back in template fields for new operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Upcoming 
 * (please add here)
 
+## 0.2.1
+* [BUGFIX] Add back in removed template fields
+
 ## 0.2.0
 * [FEATURE] Enable the use of a default Checkpoint when a Checkpoint is not supplied, with the option to use the OpenLineage Validation Action
 * [FEATURE] Add support to use Airflow connection information instead of separate Great Expectation Datasources.

--- a/great_expectations_provider/operators/great_expectations.py
+++ b/great_expectations_provider/operators/great_expectations.py
@@ -121,7 +121,9 @@ class GreatExpectationsOperator(BaseOperator):
         "data_context_root_dir",
         "checkpoint_name",
         "checkpoint_kwargs",
+        "query_to_validate"
     )
+    template_ext = (".sql")
     operator_extra_links = (GreatExpectationsDataDocsLink(),)
 
     def __init__(

--- a/great_expectations_provider/operators/great_expectations.py
+++ b/great_expectations_provider/operators/great_expectations.py
@@ -115,7 +115,13 @@ class GreatExpectationsOperator(BaseOperator):
 
     ui_color = "#AFEEEE"
     ui_fgcolor = "#000000"
-
+    template_fields = (
+        "run_name",
+        "conn_id",
+        "data_context_root_dir",
+        "checkpoint_name",
+        "checkpoint_kwargs",
+    )
     operator_extra_links = (GreatExpectationsDataDocsLink(),)
 
     def __init__(

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="airflow-provider-great-expectations",
-    version="0.2.0",
+    version="0.2.1",
     author="Great Expectations",
     description="An Apache Airflow provider for Great Expectations",
     entry_points="""

--- a/tests/operators/test_great_expectations.py
+++ b/tests/operators/test_great_expectations.py
@@ -271,6 +271,16 @@ def test_great_expectations_operator__assert_template_fields_exist():
     assert "data_context_root_dir" in operator.template_fields
     assert "checkpoint_name" in operator.template_fields
     assert "checkpoint_kwargs" in operator.template_fields
+    assert "query_to_validate" in operator.template_fields
+
+
+def test_great_expectations_operator__assert_template_ext_exist():
+    operator = GreatExpectationsOperator(
+        task_id="task_id",
+        data_context_root_dir=ge_root_dir,
+        checkpoint_name="taxi.pass.chk",
+    )
+    assert ".sql" in operator.template_ext
 
 
 def test_great_expectations_operator__context_root_dir_and_checkpoint_name_pass():

--- a/tests/operators/test_great_expectations.py
+++ b/tests/operators/test_great_expectations.py
@@ -260,6 +260,19 @@ def configured_sql_operator(in_memory_data_context_config):
     return operator
 
 
+def test_great_expectations_operator__assert_template_fields_exist():
+    operator = GreatExpectationsOperator(
+        task_id="task_id",
+        data_context_root_dir=ge_root_dir,
+        checkpoint_name="taxi.pass.chk",
+    )
+    assert "run_name" in operator.template_fields
+    assert "conn_id" in operator.template_fields
+    assert "data_context_root_dir" in operator.template_fields
+    assert "checkpoint_name" in operator.template_fields
+    assert "checkpoint_kwargs" in operator.template_fields
+
+
 def test_great_expectations_operator__context_root_dir_and_checkpoint_name_pass():
     operator = GreatExpectationsOperator(
         task_id="task_id",


### PR DESCRIPTION
Adds in template fields for:
- `run_name`
- `conn_id`
- `data_context_root_dir`
- `checkpoint_name`
- `checkpoint_kwargs`