### PR TITLE
Fix template extension bug

### DIFF
--- a/great_expectations_provider/operators/great_expectations.py
+++ b/great_expectations_provider/operators/great_expectations.py
@@ -121,9 +121,9 @@ class GreatExpectationsOperator(BaseOperator):
         "data_context_root_dir",
         "checkpoint_name",
         "checkpoint_kwargs",
-        "query_to_validate"
+        "query_to_validate",
     )
-    template_ext = (".sql")
+    template_ext = (".sql",)
     operator_extra_links = (GreatExpectationsDataDocsLink(),)
 
     def __init__(

--- a/tests/operators/test_great_expectations.py
+++ b/tests/operators/test_great_expectations.py
@@ -280,7 +280,8 @@ def test_great_expectations_operator__assert_template_ext_exist():
         data_context_root_dir=ge_root_dir,
         checkpoint_name="taxi.pass.chk",
     )
-    assert ".sql" in operator.template_ext
+    for ext in operator.template_ext:
+        assert ext == ".sql"
 
 
 def test_great_expectations_operator__context_root_dir_and_checkpoint_name_pass():


### PR DESCRIPTION
Adds a comma to the end of the template_ext set, making the quoted '.sql' a member of the set, not each character in the string a member of the set. This was breaking jinja templating. Testing has been updated to ensure the whole value, not the characters, of the elements of the template_ext set are present.