### PR TITLE
upgraded great-expectations>=0.15.34 and sqlalchemy>=1.4.44

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,8 +33,8 @@ packages = find_namespace:
 include_package_data = true
 install_requires =
     apache-airflow>=2.1
-    great-expectations>=0.13.14
-    sqlalchemy>=1.3.16
+    great-expectations==0.15.34
+    sqlalchemy==1.4.44
 
 [options.extras_require]
 tests =

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,8 +33,8 @@ packages = find_namespace:
 include_package_data = true
 install_requires =
     apache-airflow>=2.1
-    great-expectations==0.15.34
-    sqlalchemy==1.4.44
+    great-expectations>=0.15.34
+    sqlalchemy>=1.3.16
 
 [options.extras_require]
 tests =


### PR DESCRIPTION
### Upgrade great_expectation py lib version

Hi @denimalpaca,  I realized that our operator is installing `great-expectations 0.13.x ` (published on 3/17/2021) and the latest `great-expectations 0.15.x `has a lot of updates and bug fixes. 
I believe some issues related to `data_asset_name` can be resolved if we keep with the latest version of `great-expectations`
Reference: https://github.com/great-expectations/great_expectations/issues/6260

Let me know if you have any opinions and feel free to let me know what is our best practice for adding test cases.

Look forward to hearing back from you.

Thanks,

