### PR TITLE
Add schema parameter and data_asset_name parsing

### DIFF
--- a/great_expectations_provider/operators/great_expectations.py
+++ b/great_expectations_provider/operators/great_expectations.py
@@ -96,7 +96,7 @@ class GreatExpectationsOperator(BaseOperator):
     :type data_context_config: Optional[DataContextConfig]
     :param dataframe_to_validate: A pandas dataframe to validate
     :type dataframe_to_validate: Optional[str]
-    :param query_to_validate: A SQL query to validate`
+    :param query_to_validate: A SQL query to validate
     :type query_to_validate: Optional[str]
     :param checkpoint_name: A Checkpoint name to use for validation
     :type checkpoint_name: Optional[str]

--- a/great_expectations_provider/operators/great_expectations.py
+++ b/great_expectations_provider/operators/great_expectations.py
@@ -79,8 +79,6 @@ class GreatExpectationsOperator(BaseOperator):
 
     :param run_name: Identifies the validation run (defaults to timestamp if not specified)
     :type run_name: Optional[str]
-    :param conn: An Airflow Connection or dict to create a Connection
-    :type conn: Optional[Union[Connection, Dict]
     :param conn_id: The name of a connection in Airflow
     :type conn_id: Optional[str]
     :param execution_engine: The execution engine to use when running Great Expectations
@@ -133,7 +131,6 @@ class GreatExpectationsOperator(BaseOperator):
     def __init__(
         self,
         run_name: Optional[str] = None,
-        conn: Optional[Union[Connection, Dict[str, Any]]] = None,
         conn_id: Optional[str] = None,
         execution_engine: Optional[str] = None,
         expectation_suite_name: Optional[str] = None,
@@ -157,7 +154,6 @@ class GreatExpectationsOperator(BaseOperator):
 
         self.data_asset_name: Optional[str] = data_asset_name
         self.run_name: Optional[str] = run_name
-        self.conn: Optional[Union[Connection, Dict[str, Any]]] = Connection(**conn) if isinstance(conn, Dict) else conn
         self.conn_id: Optional[str] = conn_id
         self.execution_engine: Optional[str] = execution_engine
         self.expectation_suite_name: Optional[str] = expectation_suite_name

--- a/tests/operators/test_great_expectations.py
+++ b/tests/operators/test_great_expectations.py
@@ -894,7 +894,7 @@ def test_great_expectations_operator__make_connection_string_schema_parameter():
     assert operator.make_connection_string() == test_conn_str
 
 
-def test_great_expectations_operator__make_connection_string_schema_parameter():
+def test_great_expectations_operator__make_connection_string_data_asset_name_schema_parse():
     test_conn_str = (
         "snowflake://user:password@account.region-east-1/database/test_schema?warehouse=warehouse&role=role"
     )

--- a/tests/operators/test_great_expectations.py
+++ b/tests/operators/test_great_expectations.py
@@ -862,6 +862,69 @@ def test_great_expectations_operator__make_connection_string_sqlite():
     assert operator.make_connection_string() == test_conn_str
 
 
+def test_great_expectations_operator__make_connection_string_schema_parameter():
+    test_conn_str = (
+        "snowflake://user:password@account.region-east-1/database/test_schema_parameter?warehouse=warehouse&role=role"
+    )
+    operator = GreatExpectationsOperator(
+        task_id="task_id",
+        data_context_config=in_memory_data_context_config,
+        data_asset_name="test_schema.test_table",
+        conn_id="snowflake_default",
+        expectation_suite_name="suite",
+        schema="test_schema_parameter",
+    )
+    operator.conn = Connection(
+        conn_id="snowflake_default",
+        conn_type="snowflake",
+        host="connection",
+        login="user",
+        password="password",
+        schema="schema",
+        port=5439,
+        extra={
+            "extra__snowflake__role": "role",
+            "extra__snowflake__warehouse": "warehouse",
+            "extra__snowflake__database": "database",
+            "extra__snowflake__region": "region-east-1",
+            "extra__snowflake__account": "account",
+        },
+    )
+    operator.conn_type = operator.conn.conn_type
+    assert operator.make_connection_string() == test_conn_str
+
+
+def test_great_expectations_operator__make_connection_string_schema_parameter():
+    test_conn_str = (
+        "snowflake://user:password@account.region-east-1/database/test_schema?warehouse=warehouse&role=role"
+    )
+    operator = GreatExpectationsOperator(
+        task_id="task_id",
+        data_context_config=in_memory_data_context_config,
+        data_asset_name="test_schema.test_table",
+        conn_id="snowflake_default",
+        expectation_suite_name="suite",
+    )
+    operator.conn = Connection(
+        conn_id="snowflake_default",
+        conn_type="snowflake",
+        host="connection",
+        login="user",
+        password="password",
+        port=5439,
+        extra={
+            "extra__snowflake__role": "role",
+            "extra__snowflake__warehouse": "warehouse",
+            "extra__snowflake__database": "database",
+            "extra__snowflake__region": "region-east-1",
+            "extra__snowflake__account": "account",
+        },
+    )
+    operator.conn_type = operator.conn.conn_type
+    assert operator.make_connection_string() == test_conn_str
+    assert operator.data_asset_name == "test_table"
+
+
 def test_great_expectations_operator__make_connection_string_raise_error():
     operator = GreatExpectationsOperator(
         task_id="task_id",


### PR DESCRIPTION
A new schema parameter will overwrite the supplied connection's schema, if it exists. If a data_asset_name is provided in the form 'schema.table', the schema will be parsed out into self.schema and data_asset_name will be updated to only be the table. This will also override the supplied schema in the connection.

Closes: #74 