### PR TITLE
Simplify example path manipulation with `pathlib`

### DIFF
--- a/great_expectations_provider/example_dags/example_great_expectations_dag.py
+++ b/great_expectations_provider/example_dags/example_great_expectations_dag.py
@@ -2,7 +2,6 @@
 A DAG that demonstrates use of the operators in this provider package.
 """
 
-import os
 from datetime import datetime
 from pathlib import Path
 
@@ -24,13 +23,10 @@ from include.great_expectations.object_configs.example_runtime_batch_request_for
 )
 
 base_path = Path(__file__).parents[2]
-data_dir = os.path.join(base_path, "include", "data")
-data_file = os.path.join(
-    data_dir,
-    "yellow_tripdata_sample_2019-01.csv",
-)
+data_dir = base_path / "include" / "data"
+data_file = data_dir / "yellow_tripdata_sample_2019-01.csv",
 
-ge_root_dir = os.path.join(base_path, "include", "great_expectations")
+ge_root_dir = base_path / "include" / "great_expectations"
 
 
 with DAG(


### PR DESCRIPTION
Don't need to use both `os.path` and `pathlib.Path`

https://treyhunner.com/2019/01/no-really-pathlib-is-great/