### PR TITLE
[Bugfix] Remove unnecessary ValueError

### DIFF
--- a/great_expectations_provider/operators/great_expectations.py
+++ b/great_expectations_provider/operators/great_expectations.py
@@ -367,8 +367,6 @@ class GreatExpectationsOperator(BaseOperator):
                 batch_request = self.build_configured_sql_datasource_batch_request()
             else:
                 raise ValueError("Unrecognized, or lack of, runtime query or Airflow connection passed.")
-        else:
-            raise ValueError("Unrecognized, or lack of, runtime or conn_id datasource passed.")
         if not self.checkpoint_kwargs:
             self.batch_request = batch_request
 


### PR DESCRIPTION
An extraneous ValueError was in build_runtime_datasources and caused incorrect operator failure when a runtime datasource is built but a connection or dataframe is not passed in. The if/elif/else block would hit the else, which was a ValueError, and it made the below if statement on checkpoint_kwargs unreachable. It has been removed as the ValueError in the first if block is sufficient to halt operator execution in the case of incorrect usage.