### PR TITLE
Change kwargs in Snowflake URI generation

### DIFF
--- a/great_expectations_provider/operators/great_expectations.py
+++ b/great_expectations_provider/operators/great_expectations.py
@@ -22,7 +22,6 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
 
 import great_expectations as ge
-import pkg_resources
 from airflow.exceptions import AirflowException
 from airflow.hooks.base import BaseHook
 from airflow.models import BaseOperator, BaseOperatorLink, Connection, XCom

--- a/great_expectations_provider/operators/great_expectations.py
+++ b/great_expectations_provider/operators/great_expectations.py
@@ -42,6 +42,7 @@ from great_expectations.data_context.util import instantiate_class_from_config
 from great_expectations.datasource.new_datasource import Datasource
 from great_expectations.util import deep_filter_properties_iterable
 from pandas import DataFrame
+import airflow.providers.snowflake
 
 if TYPE_CHECKING:
     from airflow.utils.context import Context
@@ -245,7 +246,7 @@ class GreatExpectationsOperator(BaseOperator):
             uri_string = f"{odbc_connector}://{self.conn.login}:{self.conn.password}@{self.conn.host}:{self.conn.port}/{schema}"  # noqa
         elif conn_type == "snowflake":
             # auto generated connection kwargs Snowflake provider >=4.0.0
-            if int(pkg_resources.get_distribution("apache-airflow-providers-snowflake").version[0]) >= 4:  # noqa
+            if int(pkg_resources.get_distribution('apache-airflow-providers-snowflake==4.0.2').version[0]) >= 10:
                 uri_string = f"snowflake://{self.conn.login}:{self.conn.password}@{self.conn.extra_dejson['account']}.{self.conn.extra_dejson['region']}/{self.conn.extra_dejson['database']}/{schema}?warehouse={self.conn.extra_dejson['warehouse']}&role={self.conn.extra_dejson['role']}"  # noqa
             # auto generated connection kwargs Snowflake provider < 4.0.0
             else:

--- a/great_expectations_provider/operators/great_expectations.py
+++ b/great_expectations_provider/operators/great_expectations.py
@@ -245,8 +245,8 @@ class GreatExpectationsOperator(BaseOperator):
         elif conn_type == "snowflake":
             try:  # auto generated connection kwargs Snowflake provider >=4.0.0
                 uri_string = f"snowflake://{self.conn.login}:{self.conn.password}@{self.conn.extra_dejson['account']}.{self.conn.extra_dejson['region']}/{self.conn.extra_dejson['database']}/{schema}?warehouse={self.conn.extra_dejson['warehouse']}&role={self.conn.extra_dejson['role']}"  # noqa
-            except AirflowProviderDeprecationWarning as ex:  # auto generated connection kwargs Snowflake provider < 4.0.0
-                self.log.info(ex)
+            except KeyError:  # auto generated connection kwargs Snowflake provider < 4.0.0
+                self.log.warning("Snowflake provider >=4.0.0 updated the Snowflake hook to not use the extra prefix.")
                 uri_string = f"snowflake://{self.conn.login}:{self.conn.password}@{self.conn.extra_dejson['extra__snowflake__account']}.{self.conn.extra_dejson['extra__snowflake__region']}/{self.conn.extra_dejson['extra__snowflake__database']}/{schema}?warehouse={self.conn.extra_dejson['extra__snowflake__warehouse']}&role={self.conn.extra_dejson['extra__snowflake__role']}"
         elif conn_type == "gcpbigquery":
             uri_string = f"{self.conn.host}{schema}"

--- a/great_expectations_provider/operators/great_expectations.py
+++ b/great_expectations_provider/operators/great_expectations.py
@@ -247,7 +247,7 @@ class GreatExpectationsOperator(BaseOperator):
                 uri_string = f"snowflake://{self.conn.login}:{self.conn.password}@{self.conn.extra_dejson['account']}.{self.conn.extra_dejson['region']}/{self.conn.extra_dejson['database']}/{schema}?warehouse={self.conn.extra_dejson['warehouse']}&role={self.conn.extra_dejson['role']}"  # noqa
             except KeyError:  # auto generated connection kwargs Snowflake provider < 4.0.0
                 self.log.warning("Snowflake provider >=4.0.0 updated the Snowflake hook to not use the extra prefix.")
-                uri_string = f"snowflake://{self.conn.login}:{self.conn.password}@{self.conn.extra_dejson['extra__snowflake__account']}.{self.conn.extra_dejson['extra__snowflake__region']}/{self.conn.extra_dejson['extra__snowflake__database']}/\{schema}?warehouse={self.conn.extra_dejson['extra__snowflake__warehouse']}&role={self.conn.extra_dejson['extra__snowflake__role']}"  # noqa
+                uri_string = f"snowflake://{self.conn.login}:{self.conn.password}@{self.conn.extra_dejson['extra__snowflake__account']}.{self.conn.extra_dejson['extra__snowflake__region']}/{self.conn.extra_dejson['extra__snowflake__database']}/{schema}?warehouse={self.conn.extra_dejson['extra__snowflake__warehouse']}&role={self.conn.extra_dejson['extra__snowflake__role']}"  # noqa
         elif conn_type == "gcpbigquery":
             uri_string = f"{self.conn.host}{schema}"
         elif conn_type == "sqlite":

--- a/great_expectations_provider/operators/great_expectations.py
+++ b/great_expectations_provider/operators/great_expectations.py
@@ -247,7 +247,7 @@ class GreatExpectationsOperator(BaseOperator):
                 uri_string = f"snowflake://{self.conn.login}:{self.conn.password}@{self.conn.extra_dejson['account']}.{self.conn.extra_dejson['region']}/{self.conn.extra_dejson['database']}/{schema}?warehouse={self.conn.extra_dejson['warehouse']}&role={self.conn.extra_dejson['role']}"  # noqa
             except KeyError:  # auto generated connection kwargs Snowflake provider < 4.0.0
                 self.log.warning("Snowflake provider >=4.0.0 updated the Snowflake hook to not use the extra prefix.")
-                uri_string = f"snowflake://{self.conn.login}:{self.conn.password}@{self.conn.extra_dejson['extra__snowflake__account']}.{self.conn.extra_dejson['extra__snowflake__region']}/{self.conn.extra_dejson['extra__snowflake__database']}/\{schema}?warehouse={self.conn.extra_dejson['extra__snowflake__warehouse']}&role={self.conn.extra_dejson['extra__snowflake__role']}" # noqa
+                uri_string = f"snowflake://{self.conn.login}:{self.conn.password}@{self.conn.extra_dejson['extra__snowflake__account']}.{self.conn.extra_dejson['extra__snowflake__region']}/{self.conn.extra_dejson['extra__snowflake__database']}/\{schema}?warehouse={self.conn.extra_dejson['extra__snowflake__warehouse']}&role={self.conn.extra_dejson['extra__snowflake__role']}"  # noqa
         elif conn_type == "gcpbigquery":
             uri_string = f"{self.conn.host}{schema}"
         elif conn_type == "sqlite":

--- a/great_expectations_provider/operators/great_expectations.py
+++ b/great_expectations_provider/operators/great_expectations.py
@@ -22,7 +22,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
 
 import great_expectations as ge
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
 from airflow.hooks.base import BaseHook
 from airflow.models import BaseOperator, BaseOperatorLink, Connection, XCom
 from great_expectations.checkpoint import Checkpoint
@@ -245,7 +245,8 @@ class GreatExpectationsOperator(BaseOperator):
         elif conn_type == "snowflake":
             try:  # auto generated connection kwargs Snowflake provider >=4.0.0
                 uri_string = f"snowflake://{self.conn.login}:{self.conn.password}@{self.conn.extra_dejson['account']}.{self.conn.extra_dejson['region']}/{self.conn.extra_dejson['database']}/{schema}?warehouse={self.conn.extra_dejson['warehouse']}&role={self.conn.extra_dejson['role']}"  # noqa
-            except:  # auto generated connection kwargs Snowflake provider < 4.0.0
+            except AirflowProviderDeprecationWarning as ex:  # auto generated connection kwargs Snowflake provider < 4.0.0
+                self.log.info(ex)
                 uri_string = f"snowflake://{self.conn.login}:{self.conn.password}@{self.conn.extra_dejson['extra__snowflake__account']}.{self.conn.extra_dejson['extra__snowflake__region']}/{self.conn.extra_dejson['extra__snowflake__database']}/{schema}?warehouse={self.conn.extra_dejson['extra__snowflake__warehouse']}&role={self.conn.extra_dejson['extra__snowflake__role']}"
         elif conn_type == "gcpbigquery":
             uri_string = f"{self.conn.host}{schema}"

--- a/great_expectations_provider/operators/great_expectations.py
+++ b/great_expectations_provider/operators/great_expectations.py
@@ -245,13 +245,19 @@ class GreatExpectationsOperator(BaseOperator):
                 odbc_connector = "mssql+pyodbc"
             uri_string = f"{odbc_connector}://{self.conn.login}:{self.conn.password}@{self.conn.host}:{self.conn.port}/{schema}"  # noqa
         elif conn_type == "snowflake":
-			snowflake_account = self.conn.extra_dejson.get("account", self.conn.extra_dejson["extra__snowflake__account"])
-			snowflake_region = self.conn.extra_dejson.get("region", self.conn.extra_dejson["extra__snowflake__region"])
-			snowflake_database = self.conn.extra_dejson.get("database", self.conn.extra_dejson["extra__snowflake__database"])
-			snowflake_warehouse = self.conn.extra_dejson.get("warehouse", self.conn.extra_dejson["extra__snowflake__warehouse"])
-			snowflake_role = self.conn.extra_dejson.get("role", self.conn.extra_dejson["extra__snowflake__role"])
-			
-			uri_string = f"snowflake://{self.conn.login}:{self.conn.password}@{snowflake_account}.{snowflake_region}/{snowflake_database}/{schema}?warehouse={snowflake_warehouse}&role={snowflake_role}"
+            snowflake_account = self.conn.extra_dejson.get(
+                "account", self.conn.extra_dejson["extra__snowflake__account"]
+            )
+            snowflake_region = self.conn.extra_dejson.get("region", self.conn.extra_dejson["extra__snowflake__region"])
+            snowflake_database = self.conn.extra_dejson.get(
+                "database", self.conn.extra_dejson["extra__snowflake__database"]
+            )
+            snowflake_warehouse = self.conn.extra_dejson.get(
+                "warehouse", self.conn.extra_dejson["extra__snowflake__warehouse"]
+            )
+            snowflake_role = self.conn.extra_dejson.get("role", self.conn.extra_dejson["extra__snowflake__role"])
+
+            uri_string = f"snowflake://{self.conn.login}:{self.conn.password}@{snowflake_account}.{snowflake_region}/{snowflake_database}/{schema}?warehouse={snowflake_warehouse}&role={snowflake_role}"
         elif conn_type == "gcpbigquery":
             uri_string = f"{self.conn.host}{schema}"
         elif conn_type == "sqlite":

--- a/great_expectations_provider/operators/great_expectations.py
+++ b/great_expectations_provider/operators/great_expectations.py
@@ -243,9 +243,9 @@ class GreatExpectationsOperator(BaseOperator):
                 odbc_connector = "mssql+pyodbc"
             uri_string = f"{odbc_connector}://{self.conn.login}:{self.conn.password}@{self.conn.host}:{self.conn.port}/{schema}"  # noqa
         elif conn_type == "snowflake":
-            try: # auto generated connection kwargs Snowflake provider >=4.0.0
+            try:  # auto generated connection kwargs Snowflake provider >=4.0.0
                 uri_string = f"snowflake://{self.conn.login}:{self.conn.password}@{self.conn.extra_dejson['account']}.{self.conn.extra_dejson['region']}/{self.conn.extra_dejson['database']}/{schema}?warehouse={self.conn.extra_dejson['warehouse']}&role={self.conn.extra_dejson['role']}"  # noqa
-            except: # auto generated connection kwargs Snowflake provider < 4.0.0
+            except:  # auto generated connection kwargs Snowflake provider < 4.0.0
                 uri_string = f"snowflake://{self.conn.login}:{self.conn.password}@{self.conn.extra_dejson['extra__snowflake__account']}.{self.conn.extra_dejson['extra__snowflake__region']}/{self.conn.extra_dejson['extra__snowflake__database']}/{schema}?warehouse={self.conn.extra_dejson['extra__snowflake__warehouse']}&role={self.conn.extra_dejson['extra__snowflake__role']}"
         elif conn_type == "gcpbigquery":
             uri_string = f"{self.conn.host}{schema}"

--- a/great_expectations_provider/operators/great_expectations.py
+++ b/great_expectations_provider/operators/great_expectations.py
@@ -243,7 +243,10 @@ class GreatExpectationsOperator(BaseOperator):
                 odbc_connector = "mssql+pyodbc"
             uri_string = f"{odbc_connector}://{self.conn.login}:{self.conn.password}@{self.conn.host}:{self.conn.port}/{schema}"  # noqa
         elif conn_type == "snowflake":
-            uri_string = f"snowflake://{self.conn.login}:{self.conn.password}@{self.conn.extra_dejson['extra__snowflake__account']}.{self.conn.extra_dejson['extra__snowflake__region']}/{self.conn.extra_dejson['extra__snowflake__database']}/{schema}?warehouse={self.conn.extra_dejson['extra__snowflake__warehouse']}&role={self.conn.extra_dejson['extra__snowflake__role']}"  # noqa
+            try: # auto generated connection kwargs Snowflake provider >=4.0.0
+                uri_string = f"snowflake://{self.conn.login}:{self.conn.password}@{self.conn.extra_dejson['account']}.{self.conn.extra_dejson['region']}/{self.conn.extra_dejson['database']}/{schema}?warehouse={self.conn.extra_dejson['warehouse']}&role={self.conn.extra_dejson['role']}"  # noqa
+            except: # auto generated connection kwargs Snowflake provider < 4.0.0
+                uri_string = f"snowflake://{self.conn.login}:{self.conn.password}@{self.conn.extra_dejson['extra__snowflake__account']}.{self.conn.extra_dejson['extra__snowflake__region']}/{self.conn.extra_dejson['extra__snowflake__database']}/{schema}?warehouse={self.conn.extra_dejson['extra__snowflake__warehouse']}&role={self.conn.extra_dejson['extra__snowflake__role']}"
         elif conn_type == "gcpbigquery":
             uri_string = f"{self.conn.host}{schema}"
         elif conn_type == "sqlite":

--- a/great_expectations_provider/operators/great_expectations.py
+++ b/great_expectations_provider/operators/great_expectations.py
@@ -21,7 +21,6 @@ import os
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
 
-import airflow.providers.snowflake  # noqa
 import great_expectations as ge
 import pkg_resources
 from airflow.exceptions import AirflowException

--- a/great_expectations_provider/operators/great_expectations.py
+++ b/great_expectations_provider/operators/great_expectations.py
@@ -21,7 +21,7 @@ import os
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
 
-import airflow.providers.snowflake
+import airflow.providers.snowflake  # noqa
 import great_expectations as ge
 import pkg_resources
 from airflow.exceptions import AirflowException
@@ -246,7 +246,7 @@ class GreatExpectationsOperator(BaseOperator):
             uri_string = f"{odbc_connector}://{self.conn.login}:{self.conn.password}@{self.conn.host}:{self.conn.port}/{schema}"  # noqa
         elif conn_type == "snowflake":
             # auto generated connection kwargs Snowflake provider >=4.0.0
-            if int(pkg_resources.get_distribution("apache-airflow-providers-snowflake==4.0.2").version[0]) >= 10:
+            if int(pkg_resources.get_distribution("apache-airflow-providers-snowflake").version[0]) >= 4:
                 uri_string = f"snowflake://{self.conn.login}:{self.conn.password}@{self.conn.extra_dejson['account']}.{self.conn.extra_dejson['region']}/{self.conn.extra_dejson['database']}/{schema}?warehouse={self.conn.extra_dejson['warehouse']}&role={self.conn.extra_dejson['role']}"  # noqa
             # auto generated connection kwargs Snowflake provider < 4.0.0
             else:

--- a/great_expectations_provider/operators/great_expectations.py
+++ b/great_expectations_provider/operators/great_expectations.py
@@ -255,7 +255,7 @@ class GreatExpectationsOperator(BaseOperator):
             )
             snowflake_role = self.conn.extra_dejson.get("role", self.conn.extra_dejson["extra__snowflake__role"])
 
-            uri_string = f"snowflake://{self.conn.login}:{self.conn.password}@{snowflake_account}.{snowflake_region}/{snowflake_database}/{schema}?warehouse={snowflake_warehouse}&role={snowflake_role}"
+            uri_string = f"snowflake://{self.conn.login}:{self.conn.password}@{snowflake_account}.{snowflake_region}/{snowflake_database}/{schema}?warehouse={snowflake_warehouse}&role={snowflake_role}"  # noqa
         elif conn_type == "gcpbigquery":
             uri_string = f"{self.conn.host}{schema}"
         elif conn_type == "sqlite":

--- a/great_expectations_provider/operators/great_expectations.py
+++ b/great_expectations_provider/operators/great_expectations.py
@@ -22,6 +22,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
 
 import great_expectations as ge
+import pkg_resources
 from airflow.exceptions import AirflowException
 from airflow.hooks.base import BaseHook
 from airflow.models import BaseOperator, BaseOperatorLink, Connection, XCom
@@ -41,7 +42,6 @@ from great_expectations.data_context.util import instantiate_class_from_config
 from great_expectations.datasource.new_datasource import Datasource
 from great_expectations.util import deep_filter_properties_iterable
 from pandas import DataFrame
-import pkg_resources
 
 if TYPE_CHECKING:
     from airflow.utils.context import Context

--- a/great_expectations_provider/operators/great_expectations.py
+++ b/great_expectations_provider/operators/great_expectations.py
@@ -22,7 +22,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
 
 import great_expectations as ge
-from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
+from airflow.exceptions import AirflowException
 from airflow.hooks.base import BaseHook
 from airflow.models import BaseOperator, BaseOperatorLink, Connection, XCom
 from great_expectations.checkpoint import Checkpoint
@@ -247,7 +247,7 @@ class GreatExpectationsOperator(BaseOperator):
                 uri_string = f"snowflake://{self.conn.login}:{self.conn.password}@{self.conn.extra_dejson['account']}.{self.conn.extra_dejson['region']}/{self.conn.extra_dejson['database']}/{schema}?warehouse={self.conn.extra_dejson['warehouse']}&role={self.conn.extra_dejson['role']}"  # noqa
             except KeyError:  # auto generated connection kwargs Snowflake provider < 4.0.0
                 self.log.warning("Snowflake provider >=4.0.0 updated the Snowflake hook to not use the extra prefix.")
-                uri_string = f"snowflake://{self.conn.login}:{self.conn.password}@{self.conn.extra_dejson['extra__snowflake__account']}.{self.conn.extra_dejson['extra__snowflake__region']}/{self.conn.extra_dejson['extra__snowflake__database']}/{schema}?warehouse={self.conn.extra_dejson['extra__snowflake__warehouse']}&role={self.conn.extra_dejson['extra__snowflake__role']}"
+                uri_string = f"snowflake://{self.conn.login}:{self.conn.password}@{self.conn.extra_dejson['extra__snowflake__account']}.{self.conn.extra_dejson['extra__snowflake__region']}/{self.conn.extra_dejson['extra__snowflake__database']}/\{schema}?warehouse={self.conn.extra_dejson['extra__snowflake__warehouse']}&role={self.conn.extra_dejson['extra__snowflake__role']}" # noqa
         elif conn_type == "gcpbigquery":
             uri_string = f"{self.conn.host}{schema}"
         elif conn_type == "sqlite":

--- a/great_expectations_provider/operators/great_expectations.py
+++ b/great_expectations_provider/operators/great_expectations.py
@@ -245,13 +245,13 @@ class GreatExpectationsOperator(BaseOperator):
                 odbc_connector = "mssql+pyodbc"
             uri_string = f"{odbc_connector}://{self.conn.login}:{self.conn.password}@{self.conn.host}:{self.conn.port}/{schema}"  # noqa
         elif conn_type == "snowflake":
-            # auto generated connection kwargs Snowflake provider >=4.0.0
-            if int(pkg_resources.get_distribution("apache-airflow-providers-snowflake").version[0]) >= 4:
-                uri_string = f"snowflake://{self.conn.login}:{self.conn.password}@{self.conn.extra_dejson['account']}.{self.conn.extra_dejson['region']}/{self.conn.extra_dejson['database']}/{schema}?warehouse={self.conn.extra_dejson['warehouse']}&role={self.conn.extra_dejson['role']}"  # noqa
-            # auto generated connection kwargs Snowflake provider < 4.0.0
-            else:
-                self.log.warning("Snowflake provider >=4.0.0 updated the Snowflake hook to not use the extra prefix.")
-                uri_string = f"snowflake://{self.conn.login}:{self.conn.password}@{self.conn.extra_dejson['extra__snowflake__account']}.{self.conn.extra_dejson['extra__snowflake__region']}/{self.conn.extra_dejson['extra__snowflake__database']}/{schema}?warehouse={self.conn.extra_dejson['extra__snowflake__warehouse']}&role={self.conn.extra_dejson['extra__snowflake__role']}"  # noqa
+			snowflake_account = self.conn.extra_dejson.get("account", self.conn.extra_dejson["extra__snowflake__account"])
+			snowflake_region = self.conn.extra_dejson.get("region", self.conn.extra_dejson["extra__snowflake__region"])
+			snowflake_database = self.conn.extra_dejson.get("database", self.conn.extra_dejson["extra__snowflake__database"])
+			snowflake_warehouse = self.conn.extra_dejson.get("warehouse", self.conn.extra_dejson["extra__snowflake__warehouse"])
+			snowflake_role = self.conn.extra_dejson.get("role", self.conn.extra_dejson["extra__snowflake__role"])
+			
+			uri_string = f"snowflake://{self.conn.login}:{self.conn.password}@{snowflake_account}.{snowflake_region}/{snowflake_database}/{schema}?warehouse={snowflake_warehouse}&role={snowflake_role}"
         elif conn_type == "gcpbigquery":
             uri_string = f"{self.conn.host}{schema}"
         elif conn_type == "sqlite":

--- a/great_expectations_provider/operators/great_expectations.py
+++ b/great_expectations_provider/operators/great_expectations.py
@@ -245,7 +245,7 @@ class GreatExpectationsOperator(BaseOperator):
             uri_string = f"{odbc_connector}://{self.conn.login}:{self.conn.password}@{self.conn.host}:{self.conn.port}/{schema}"  # noqa
         elif conn_type == "snowflake":
             # auto generated connection kwargs Snowflake provider >=4.0.0
-            if int(pkg_resources.get_distribution("apache-airflow-providers-snowflake").version[0]) >= 4:
+            if int(pkg_resources.get_distribution("apache-airflow-providers-snowflake").version[0]) >= 4:  # noqa
                 uri_string = f"snowflake://{self.conn.login}:{self.conn.password}@{self.conn.extra_dejson['account']}.{self.conn.extra_dejson['region']}/{self.conn.extra_dejson['database']}/{schema}?warehouse={self.conn.extra_dejson['warehouse']}&role={self.conn.extra_dejson['role']}"  # noqa
             # auto generated connection kwargs Snowflake provider < 4.0.0
             else:

--- a/great_expectations_provider/operators/great_expectations.py
+++ b/great_expectations_provider/operators/great_expectations.py
@@ -21,6 +21,7 @@ import os
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
 
+import airflow.providers.snowflake
 import great_expectations as ge
 import pkg_resources
 from airflow.exceptions import AirflowException
@@ -42,7 +43,6 @@ from great_expectations.data_context.util import instantiate_class_from_config
 from great_expectations.datasource.new_datasource import Datasource
 from great_expectations.util import deep_filter_properties_iterable
 from pandas import DataFrame
-import airflow.providers.snowflake
 
 if TYPE_CHECKING:
     from airflow.utils.context import Context
@@ -246,7 +246,7 @@ class GreatExpectationsOperator(BaseOperator):
             uri_string = f"{odbc_connector}://{self.conn.login}:{self.conn.password}@{self.conn.host}:{self.conn.port}/{schema}"  # noqa
         elif conn_type == "snowflake":
             # auto generated connection kwargs Snowflake provider >=4.0.0
-            if int(pkg_resources.get_distribution('apache-airflow-providers-snowflake==4.0.2').version[0]) >= 10:
+            if int(pkg_resources.get_distribution("apache-airflow-providers-snowflake==4.0.2").version[0]) >= 10:
                 uri_string = f"snowflake://{self.conn.login}:{self.conn.password}@{self.conn.extra_dejson['account']}.{self.conn.extra_dejson['region']}/{self.conn.extra_dejson['database']}/{schema}?warehouse={self.conn.extra_dejson['warehouse']}&role={self.conn.extra_dejson['role']}"  # noqa
             # auto generated connection kwargs Snowflake provider < 4.0.0
             else:


### PR DESCRIPTION
Fixes #83 . 
Snowflake provider 4.0.0 changed the kwargs generated when the connection is defined in the Airflow UI. I left the old kwargs as a fallback.