### PR TITLE
Add Athena Connection Support

### DIFF
--- a/great_expectations_provider/operators/great_expectations.py
+++ b/great_expectations_provider/operators/great_expectations.py
@@ -292,13 +292,13 @@ class GreatExpectationsOperator(BaseOperator):
         elif conn_type == "aws":
             # TODO: Check which AWS resource is being used based on the hook. This is difficult because
             # we don't have access to a specific hook.
-            athena_db = schema or self.kwargs.get("database")
-            s3_path = self.kwargs.get("s3_path")
-            region = self.kwargs.get("region")
+            athena_db = schema or self.params.get("database")
+            s3_path = self.params.get("s3_path")
+            region = self.params.get("region")
             if not s3_path:
-                raise ValueError("No s3_path given in kwargs.")
+                raise ValueError("No s3_path given in params.")
             if not region:
-                raise ValueError("No region given in kwargs.")
+                raise ValueError("No region given in params.")
             if athena_db:
                 uri_string = f"awsathena+rest://@athena.{region}.amazonaws.com/{athena_db}?s3_staging_dir={s3_path}"
             else:

--- a/great_expectations_provider/operators/great_expectations.py
+++ b/great_expectations_provider/operators/great_expectations.py
@@ -292,7 +292,7 @@ class GreatExpectationsOperator(BaseOperator):
         elif conn_type == "aws":
             # TODO: Check which AWS resource is being used based on the hook. This is difficult because
             # we don't have access to a specific hook.
-            athena_db = schema or self.params.get("database")
+            athena_db = self.schema or self.params.get("database")
             s3_path = self.params.get("s3_path")
             region = self.params.get("region")
             if not s3_path:

--- a/great_expectations_provider/operators/great_expectations.py
+++ b/great_expectations_provider/operators/great_expectations.py
@@ -175,6 +175,7 @@ class GreatExpectationsOperator(BaseOperator):
         self.datasource: Optional[Datasource] = None
         self.batch_request: Optional[BatchRequestBase] = None
         self.schema = schema
+        self.kwargs = kwargs
 
         if self.is_dataframe and self.query_to_validate:
             raise ValueError(
@@ -288,7 +289,22 @@ class GreatExpectationsOperator(BaseOperator):
             uri_string = f"{self.conn.host}{self.schema}"
         elif conn_type == "sqlite":
             uri_string = f"sqlite:///{self.conn.host}"
-        # TODO: Add Athena and Trino support if possible
+        elif conn_type == "aws":
+            # TODO: Check which AWS resource is being used based on the hook. This is difficult because
+            # we don't have access to a specific hook.
+            athena_db = schema or self.kwargs.get("database")
+            s3_path = self.kwargs.get("s3_path")
+            region = self.kwargs.get("region")
+            if not s3_path:
+                raise ValueError("No s3_path given in kwargs.")
+            if not region:
+                raise ValueError("No region given in kwargs.")
+            if athena_db:
+                uri_string = f"awsathena+rest://@athena.{region}.amazonaws.com/{athena_db}?s3_staging_dir={s3_path}"
+            else:
+                uri_string = f"awsathena+rest://@athena.{region}.amazonaws.com/?s3_staging_dir={s3_path}"
+            # TODO: Add other AWS sources here as needed
+        # TODO: Add and Trino support (if possible)
         else:
             raise ValueError(f"Conn type: {conn_type} is not supported.")
         return {"connection_string": uri_string}

--- a/tests/operators/test_great_expectations.py
+++ b/tests/operators/test_great_expectations.py
@@ -938,10 +938,7 @@ def test_great_expectations_operator__make_connection_string_athena_with_db():
         data_asset_name="athena_db.table_name",
         conn_id="aws_default",
         expectation_suite_name="suite",
-        params={
-            "region": "us-east-1",
-            "s3_path": "bucket/path/to/staging/dir"
-        }
+        params={"region": "us-east-1", "s3_path": "bucket/path/to/staging/dir"},
     )
     operator.conn = Connection(
         conn_id="aws_default",

--- a/tests/operators/test_great_expectations.py
+++ b/tests/operators/test_great_expectations.py
@@ -931,9 +931,9 @@ def test_great_expectations_operator__make_connection_string_sqlite():
 
 
 def test_great_expectations_operator__make_connection_string_athena_with_db():
-    test_conn_str = (
-        "awsathena+rest://@athena.us-east-1.amazonaws.com/athena_db?s3_staging_dir=bucket/path/to/staging/dir"
-    )
+    test_conn_conf = {
+        "connection_string": "awsathena+rest://@athena.us-east-1.amazonaws.com/athena_db?s3_staging_dir=bucket/path/to/staging/dir" # noqa
+    }
     operator = GreatExpectationsOperator(
         task_id="task_id",
         data_context_config=in_memory_data_context_config,
@@ -948,11 +948,13 @@ def test_great_expectations_operator__make_connection_string_athena_with_db():
         host="host",
     )
     operator.conn_type = operator.conn.conn_type
-    assert operator.make_connection_configuration() == test_conn_str
+    assert operator.make_connection_configuration() == test_conn_conf
 
 
 def test_great_expectations_operator__make_connection_string_athena_without_db():
-    test_conn_str = "awsathena+rest://@athena.us-east-1.amazonaws.com/?s3_staging_dir=bucket/path/to/staging/dir"
+    test_conn_conf = {
+        "connection_string": "awsathena+rest://@athena.us-east-1.amazonaws.com/?s3_staging_dir=bucket/path/to/staging/dir" # noqa
+    }
     operator = GreatExpectationsOperator(
         task_id="task_id",
         data_context_config=in_memory_data_context_config,
@@ -967,7 +969,7 @@ def test_great_expectations_operator__make_connection_string_athena_without_db()
         host="host",
     )
     operator.conn_type = operator.conn.conn_type
-    assert operator.make_connection_configuration() == test_conn_str
+    assert operator.make_connection_configuration() == test_conn_conf
 
 
 def test_great_expectations_operator__make_connection_string_schema_parameter(mocker):

--- a/tests/operators/test_great_expectations.py
+++ b/tests/operators/test_great_expectations.py
@@ -932,7 +932,7 @@ def test_great_expectations_operator__make_connection_string_sqlite():
 
 def test_great_expectations_operator__make_connection_string_athena_with_db():
     test_conn_conf = {
-        "connection_string": "awsathena+rest://@athena.us-east-1.amazonaws.com/athena_db?s3_staging_dir=bucket/path/to/staging/dir" # noqa
+        "connection_string": "awsathena+rest://@athena.us-east-1.amazonaws.com/athena_db?s3_staging_dir=bucket/path/to/staging/dir"  # noqa
     }
     operator = GreatExpectationsOperator(
         task_id="task_id",
@@ -953,7 +953,7 @@ def test_great_expectations_operator__make_connection_string_athena_with_db():
 
 def test_great_expectations_operator__make_connection_string_athena_without_db():
     test_conn_conf = {
-        "connection_string": "awsathena+rest://@athena.us-east-1.amazonaws.com/?s3_staging_dir=bucket/path/to/staging/dir" # noqa
+        "connection_string": "awsathena+rest://@athena.us-east-1.amazonaws.com/?s3_staging_dir=bucket/path/to/staging/dir"  # noqa
     }
     operator = GreatExpectationsOperator(
         task_id="task_id",
@@ -973,9 +973,6 @@ def test_great_expectations_operator__make_connection_string_athena_without_db()
 
 
 def test_great_expectations_operator__make_connection_string_schema_parameter(mocker):
-    test_conn_str = (
-        "snowflake://user:password@account.region-east-1/database/test_schema_parameter?warehouse=warehouse&role=role"
-    )
     test_conn_conf = {
         "url": URL.create(
             drivername="snowflake",

--- a/tests/operators/test_great_expectations.py
+++ b/tests/operators/test_great_expectations.py
@@ -939,7 +939,7 @@ def test_great_expectations_operator__make_connection_string_athena_with_db():
         conn_id="aws_default",
         expectation_suite_name="suite",
         region="us-east-1",
-        s3_path="bucket/path/to/staging/dir"
+        s3_path="bucket/path/to/staging/dir",
     )
     operator.conn = Connection(
         conn_id="aws_default",

--- a/tests/operators/test_great_expectations.py
+++ b/tests/operators/test_great_expectations.py
@@ -970,13 +970,10 @@ def test_great_expectations_operator__make_connection_string_athena_without_db()
     assert operator.make_connection_configuration() == test_conn_str
 
 
-def test_great_expectations_operator__make_connection_string_schema_parameter():
+def test_great_expectations_operator__make_connection_string_schema_parameter(mocker):
     test_conn_str = (
         "snowflake://user:password@account.region-east-1/database/test_schema_parameter?warehouse=warehouse&role=role"
     )
-
-
-def test_great_expectations_operator__make_connection_string_schema_parameter(mocker):
     test_conn_conf = {
         "url": URL.create(
             drivername="snowflake",

--- a/tests/operators/test_great_expectations.py
+++ b/tests/operators/test_great_expectations.py
@@ -938,8 +938,10 @@ def test_great_expectations_operator__make_connection_string_athena_with_db():
         data_asset_name="athena_db.table_name",
         conn_id="aws_default",
         expectation_suite_name="suite",
-        region="us-east-1",
-        s3_path="bucket/path/to/staging/dir",
+        params={
+            "region": "us-east-1",
+            "s3_path": "bucket/path/to/staging/dir"
+        }
     )
     operator.conn = Connection(
         conn_id="aws_default",

--- a/tests/operators/test_great_expectations.py
+++ b/tests/operators/test_great_expectations.py
@@ -930,6 +930,26 @@ def test_great_expectations_operator__make_connection_string_sqlite():
     assert operator.make_connection_configuration() == test_conn_conf
 
 
+def test_great_expectations_operator__make_connection_string_athena_with_db():
+    test_conn_str = "awsathena+rest://@athena.us-east-1.amazonaws.com/athena_db?s3_staging_dir=bucket/path/to/staging/dir"
+    operator = GreatExpectationsOperator(
+        task_id="task_id",
+        data_context_config=in_memory_data_context_config,
+        data_asset_name="athena_db.table_name",
+        conn_id="aws_default",
+        expectation_suite_name="suite",
+        region="us-east-1",
+        s3_path="bucket/path/to/staging/dir"
+    )
+    operator.conn = Connection(
+        conn_id="aws_default",
+        conn_type="aws",
+        host="host",
+    )
+    operator.conn_type = operator.conn.conn_type
+    assert operator.make_connection_configuration() == test_conn_conf
+
+
 def test_great_expectations_operator__make_connection_string_schema_parameter(mocker):
     test_conn_conf = {
         "url": URL.create(


### PR DESCRIPTION
Add an Athena URI builder to make_connection_string(), assuming for now that Athena is the only connection when an AWS connection type is given. This is an incorrect assumption, but we currently do not have asks for other use cases figuring out how to differentiate these may be a non-trivial issue.

Closes: #90 