### PR TITLE
Snowflake key auth

### DIFF
--- a/great_expectations_provider/operators/great_expectations.py
+++ b/great_expectations_provider/operators/great_expectations.py
@@ -264,6 +264,15 @@ class GreatExpectationsOperator(BaseOperator):
             snowflake_role = self.conn.extra_dejson.get("role", self.conn.extra_dejson["extra__snowflake__role"])
 
             uri_string = f"snowflake://{self.conn.login}:{self.conn.password}@{snowflake_account}.{snowflake_region}/{snowflake_database}/{schema}?warehouse={snowflake_warehouse}&role={snowflake_role}"  # noqa
+
+            # private_key_file is optional, see:
+            # https://docs.snowflake.com/en/user-guide/sqlalchemy.html#key-pair-authentication-support
+            snowflake_private_key_file = self.conn.extra_dejson.get(
+                "private_key_file", self.conn.extra_dejson.get("extra__snowflake__private_key_file")
+            )
+            if snowflake_private_key_file:
+                uri_string += f"&private_key_file={snowflake_private_key_file}"
+
         elif conn_type == "gcpbigquery":
             uri_string = f"{self.conn.host}{schema}"
         elif conn_type == "sqlite":

--- a/tests/operators/test_great_expectations.py
+++ b/tests/operators/test_great_expectations.py
@@ -815,7 +815,10 @@ def test_great_expectations_operator__make_connection_string_mssql():
 
 
 def test_great_expectations_operator__make_connection_string_snowflake():
-    test_conn_str = "snowflake://user:password@account.region-east-1/database/schema?warehouse=warehouse&role=role"
+    test_conn_str = (
+        "snowflake://user:password@account.region-east-1/"
+        "database/schema?warehouse=warehouse&role=role&private_key_file=/path/to/key.p8"
+    )
     operator = GreatExpectationsOperator(
         task_id="task_id",
         data_context_config=in_memory_data_context_config,
@@ -838,6 +841,7 @@ def test_great_expectations_operator__make_connection_string_snowflake():
             "extra__snowflake__database": "database",
             "extra__snowflake__region": "region-east-1",
             "extra__snowflake__account": "account",
+            "extra__snowflake__private_key_file": "/path/to/key.p8",
         },
     )
     operator.conn_type = operator.conn.conn_type


### PR DESCRIPTION
This adds support for Snowflake key based auth, see: https://docs.snowflake.com/en/user-guide/sqlalchemy.html#key-pair-authentication-support