### PR TITLE
Fixes #110 and #107

### DIFF
--- a/great_expectations_provider/operators/great_expectations.py
+++ b/great_expectations_provider/operators/great_expectations.py
@@ -268,9 +268,9 @@ class GreatExpectationsOperator(BaseOperator):
             snowflake_account = (
                 self.conn.extra_dejson.get("account") or self.conn.extra_dejson["extra__snowflake__account"]
             )
-            snowflake_region = (
-                self.conn.extra_dejson.get("region") or self.conn.extra_dejson.get("extra__snowflake__region")  #Snowflake region can be None for us-west-2
-            )
+            snowflake_region = self.conn.extra_dejson.get("region") or self.conn.extra_dejson.get(
+                "extra__snowflake__region"
+            )  # Snowflake region can be None for us-west-2
             snowflake_database = (
                 self.conn.extra_dejson.get("database") or self.conn.extra_dejson["extra__snowflake__database"]
             )

--- a/great_expectations_provider/operators/great_expectations.py
+++ b/great_expectations_provider/operators/great_expectations.py
@@ -269,7 +269,7 @@ class GreatExpectationsOperator(BaseOperator):
                 self.conn.extra_dejson.get("account") or self.conn.extra_dejson["extra__snowflake__account"]
             )
             snowflake_region = (
-                self.conn.extra_dejson.get("region") or self.conn.extra_dejson["extra__snowflake__region"]
+                self.conn.extra_dejson.get("region") or self.conn.extra_dejson.get("extra__snowflake__region")  #Snowflake region can be None for us-west-2
             )
             snowflake_database = (
                 self.conn.extra_dejson.get("database") or self.conn.extra_dejson["extra__snowflake__database"]
@@ -279,7 +279,10 @@ class GreatExpectationsOperator(BaseOperator):
             )
             snowflake_role = self.conn.extra_dejson.get("role") or self.conn.extra_dejson["extra__snowflake__role"]
 
-            uri_string = f"snowflake://{self.conn.login}:{self.conn.password}@{snowflake_account}.{snowflake_region}/{snowflake_database}/{self.schema}?warehouse={snowflake_warehouse}&role={snowflake_role}"  # noqa
+            if snowflake_region:
+                uri_string = f"snowflake://{self.conn.login}:{self.conn.password}@{snowflake_account}.{snowflake_region}/{snowflake_database}/{self.schema}?warehouse={snowflake_warehouse}&role={snowflake_role}"  # noqa
+            else:
+                uri_string = f"snowflake://{self.conn.login}:{self.conn.password}@{snowflake_account}/{snowflake_database}/{self.schema}?warehouse={snowflake_warehouse}&role={snowflake_role}"  # noqa
 
         elif conn_type == "gcpbigquery":
             uri_string = f"{self.conn.host}{self.schema}"


### PR DESCRIPTION
Addes a new attribute and operator arg for database override and parses data_asset_name for either TABLE, SCHEMA.TABLE or DATABASE.SCHEMA.TABLE.  

Due to differences in how schema and database are used across database providers it may not be possible to use BaseHook to get hook and conn attributes for all variants.  This PR allows redshift and postgres users to specify db and schema either as operator args or fully-qualified data_asset_name arg.