### PR TITLE
Fix make_connection_configuration for MSSQL (adding a driver)

### DIFF
--- a/great_expectations_provider/operators/great_expectations.py
+++ b/great_expectations_provider/operators/great_expectations.py
@@ -257,7 +257,10 @@ class GreatExpectationsOperator(BaseOperator):
                 ms_driver = self.conn.extra_dejson.get("driver") or "ODBC Driver 17 for SQL Server"
                 driver = f"?driver={ms_driver}"
                 database_name = self.conn.schema
-            uri_string = f"{odbc_connector}://{self.conn.login}:{self.conn.password}@{self.conn.host}:{self.conn.port}/{database_name}{driver}"  # no qa
+            uri_string = (
+                f"{odbc_connector}://{self.conn.login}:{self.conn.password}@"
+                f"{self.conn.host}:{self.conn.port}/{database_name}{driver}"
+            )
         elif conn_type == "snowflake":
             try:
                 return self.build_snowflake_connection_config_from_hook()

--- a/great_expectations_provider/operators/great_expectations.py
+++ b/great_expectations_provider/operators/great_expectations.py
@@ -256,7 +256,7 @@ class GreatExpectationsOperator(BaseOperator):
                 odbc_connector = "mssql+pyodbc"
                 ms_driver = self.conn.extra_dejson.get("driver") or "ODBC Driver 17 for SQL Server"
                 driver = f"?driver={ms_driver}"
-                database_name = self.conn.schema
+                database_name = self.conn.schema or "master"
             else:
                 raise ValueError(f"Conn type: {conn_type} is not supported.")
             uri_string = (

--- a/great_expectations_provider/operators/great_expectations.py
+++ b/great_expectations_provider/operators/great_expectations.py
@@ -254,10 +254,7 @@ class GreatExpectationsOperator(BaseOperator):
                 database_name = self.schema
             else:
                 odbc_connector = "mssql+pyodbc"
-                ms_driver = (
-                    self.conn.extra_dejson.get("driver")
-                    or "ODBC Driver 17 for SQL Server"
-                )
+                ms_driver = self.conn.extra_dejson.get("driver") or "ODBC Driver 17 for SQL Server"
                 driver = f"?driver={ms_driver}"
                 database_name = self.conn.schema
             uri_string = f"{odbc_connector}://{self.conn.login}:{self.conn.password}@{self.conn.host}:{self.conn.port}/{database_name}{driver}"  # no qa

--- a/great_expectations_provider/operators/great_expectations.py
+++ b/great_expectations_provider/operators/great_expectations.py
@@ -252,11 +252,13 @@ class GreatExpectationsOperator(BaseOperator):
             elif conn_type == "mysql":
                 odbc_connector = "mysql"
                 database_name = self.schema
-            else:
+            elif conn_type == "mssql":
                 odbc_connector = "mssql+pyodbc"
                 ms_driver = self.conn.extra_dejson.get("driver") or "ODBC Driver 17 for SQL Server"
                 driver = f"?driver={ms_driver}"
                 database_name = self.conn.schema
+            else:
+                raise ValueError(f"Conn type: {conn_type} is not supported.")
             uri_string = (
                 f"{odbc_connector}://{self.conn.login}:{self.conn.password}@"
                 f"{self.conn.host}:{self.conn.port}/{database_name}{driver}"

--- a/tests/operators/test_great_expectations.py
+++ b/tests/operators/test_great_expectations.py
@@ -793,7 +793,7 @@ def test_great_expectations_operator__make_connection_string_mysql():
 
 
 def test_great_expectations_operator__make_connection_string_mssql():
-    test_conn_conf = {"connection_string": "mssql+pyodbc://user:password@connection:5439/schema"}
+    test_conn_conf = {"connection_string": "mssql+pyodbc://user:password@connection:5439/schema?driver=driver"}
     operator = GreatExpectationsOperator(
         task_id="task_id",
         data_context_config=in_memory_data_context_config,
@@ -810,6 +810,7 @@ def test_great_expectations_operator__make_connection_string_mssql():
         password="password",
         schema="schema",
         port=5439,
+        extra='{"driver": "driver"}',
     )
     operator.conn_type = operator.conn.conn_type
     assert operator.make_connection_configuration() == test_conn_conf


### PR DESCRIPTION
Hi :) 

This came up in the GX Slack twice. Using the GXO with a MSSQL conn_id currently does not work because there is no driver being passed via the URI. If fails with:

```
sqlalchemy.exc.InterfaceError: (pyodbc.InterfaceError) ('IM002', '[IM002] [Microsoft][ODBC Driver Manager] Data source name not found and no default driver specified (0) (SQLDriverConnect)')
```

There was also an issue with the connection needing a database argument separate from the schema passed through the operator.

This PR should fix that. I added the possibility to pass a driver via the connection extras, if none is passed `ODBC Driver 17 for SQL Server` is passed, which is what worked for me when testing with the `mcr.microsoft.com/mssql/server:2022-latest` image. 
I tested this change with Postgres and MSSQL. :)

@phanikumv I hope it is ok to tag you for review on this, Viraj told me you might be able to help :)