### PR TITLE
add schema as a template field

### DIFF
--- a/great_expectations_provider/operators/great_expectations.py
+++ b/great_expectations_provider/operators/great_expectations.py
@@ -125,6 +125,7 @@ class GreatExpectationsOperator(BaseOperator):
         "checkpoint_name",
         "checkpoint_kwargs",
         "query_to_validate",
+        "schema",
     )
     template_ext = (".sql",)
     operator_extra_links = (GreatExpectationsDataDocsLink(),)

--- a/tests/operators/test_great_expectations.py
+++ b/tests/operators/test_great_expectations.py
@@ -267,6 +267,7 @@ def test_great_expectations_operator__assert_template_fields_exist():
     assert "checkpoint_name" in operator.template_fields
     assert "checkpoint_kwargs" in operator.template_fields
     assert "query_to_validate" in operator.template_fields
+    assert "schema" in operator.template_fields
 
 
 def test_great_expectations_operator__assert_template_ext_exist():


### PR DESCRIPTION
There was a requirement in the work I am doing to dynamically set the `schema` property from a REST API request. So I am adding `schema` as a template field so it can be set using `params`.