### PR TITLE
Fix #148 compatibility issue  with great_expectations 1.0.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ packages = find_namespace:
 include_package_data = true
 install_requires =
     apache-airflow>=2.1
-    great-expectations>=0.15.34
+    great-expectations<=1.0.0, >=0.15.34
     sqlalchemy>=1.3.16
 
 [options.extras_require]

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ packages = find_namespace:
 include_package_data = true
 install_requires =
     apache-airflow>=2.1
-    great-expectations<=1.0.0, >=0.15.34
+    great-expectations<1.0.0, >=0.15.34
     sqlalchemy>=1.3.16
 
 [options.extras_require]


### PR DESCRIPTION
airflow-provider-great-expectations is not compatible with great_expectations 1.0.0

Closes #148



airflow-provider-great-expectations is not compatible with great_expectations 1.0.0

CheckpointResult has been removed so the following import is currently failing!
from great_expectations.checkpoint.types.checkpoint_result import **CheckpointResult**

https://github.com/astronomer/airflow-provider-great-expectations/blob/main/great_expectations_provider/operators/great_expectations.py#L30

great-expectations PR that made the changes: https://github.com/great-expectations/great_expectations/pull/9824