### PR TITLE
Add deprecation warnings for existing operators

### DIFF
--- a/great_expectations_provider/operators/great_expectations.py
+++ b/great_expectations_provider/operators/great_expectations.py
@@ -55,6 +55,7 @@ class GreatExpectationsDataDocsLink(BaseOperatorLink):
 
     Constructs a link to Great Expectations data docs site.
     """
+
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         warnings.warn(
             (

--- a/great_expectations_provider/operators/great_expectations.py
+++ b/great_expectations_provider/operators/great_expectations.py
@@ -18,6 +18,7 @@
 #
 
 import os
+import warnings
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
@@ -48,7 +49,22 @@ if TYPE_CHECKING:
 
 
 class GreatExpectationsDataDocsLink(BaseOperatorLink):
-    """Constructs a link to Great Expectations data docs site."""
+    """
+    This class is deprecated and will be removed in an upcoming release where operators supporting GX Core 1.x will be
+    added.
+
+    Constructs a link to Great Expectations data docs site.
+    """
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        warnings.warn(
+            (
+                "This class is deprecated and will be removed in an upcoming release where operators supporting "
+                "GX Core 1.x will be added."
+            ),
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(*args, **kwargs)
 
     @property
     def name(self):
@@ -70,6 +86,9 @@ class GreatExpectationsDataDocsLink(BaseOperatorLink):
 
 class GreatExpectationsOperator(BaseOperator):
     """
+    This class is deprecated and will be removed in an upcoming release where operators supporting GX Core 1.x will be
+    added.
+
     An operator to leverage Great Expectations as a task in your Airflow DAG.
 
     Current list of expectations types:
@@ -153,6 +172,14 @@ class GreatExpectationsOperator(BaseOperator):
         *args,
         **kwargs,
     ) -> None:
+        warnings.warn(
+            (
+                "This class is deprecated and will be removed in an upcoming release where operators supporting "
+                "GX Core 1.x will be added."
+            ),
+            DeprecationWarning,
+            stacklevel=2,
+        )
         super().__init__(*args, **kwargs)
 
         self.data_asset_name: Optional[str] = data_asset_name

--- a/tests/operators/test_great_expectations.py
+++ b/tests/operators/test_great_expectations.py
@@ -31,7 +31,8 @@ from great_expectations.exceptions.exceptions import CheckpointNotFoundError
 from sqlalchemy.engine import URL
 
 from great_expectations_provider.operators.great_expectations import (
-    GreatExpectationsOperator, GreatExpectationsDataDocsLink,
+    GreatExpectationsDataDocsLink,
+    GreatExpectationsOperator,
 )
 
 logger = logging.getLogger(__name__)
@@ -1217,4 +1218,3 @@ def test_great_expectations_operator_deprecation():
             data_context_config=in_memory_data_context_config,
             expectation_suite_name="taxi.demo",
         )
-

--- a/tests/operators/test_great_expectations.py
+++ b/tests/operators/test_great_expectations.py
@@ -31,7 +31,7 @@ from great_expectations.exceptions.exceptions import CheckpointNotFoundError
 from sqlalchemy.engine import URL
 
 from great_expectations_provider.operators.great_expectations import (
-    GreatExpectationsOperator,
+    GreatExpectationsOperator, GreatExpectationsDataDocsLink,
 )
 
 logger = logging.getLogger(__name__)
@@ -1203,3 +1203,18 @@ def test_great_expectations_operator__make_connection_string_raise_error():
     operator.conn_type = operator.conn.conn_type
     with pytest.raises(ValueError):
         operator.make_connection_configuration()
+
+
+def test_great_expectations_data_docs_link_deprecation():
+    with pytest.warns(DeprecationWarning, match="This class is deprecated and will be removed in an upcoming release"):
+        GreatExpectationsDataDocsLink()
+
+
+def test_great_expectations_operator_deprecation():
+    with pytest.warns(DeprecationWarning, match="This class is deprecated and will be removed in an upcoming release"):
+        GreatExpectationsOperator(
+            task_id="task_id",
+            data_context_config=in_memory_data_context_config,
+            expectation_suite_name="taxi.demo",
+        )
+


### PR DESCRIPTION
Since we’re preparing a release to include support for GX Core 1.0 and plan to remove existing operators in an upcoming release (as part of the work in PR #161), this PR adds a deprecation warning for the current operators.


related: #166 