### PR TITLE
Set version statically to let verify_tag script pass

### DIFF
--- a/great_expectations_provider/__init__.py
+++ b/great_expectations_provider/__init__.py
@@ -1,3 +1,4 @@
-from great_expectations_provider.common.constants import VERSION
+# TODO: Update the .github/scripts/verify_tag_and_version.py script so that we can use the VERSION from the
+#  great_expectation_provider/common/constants.py file.
 
-__version__ = VERSION
+__version__ = "1.0.0a1"


### PR DESCRIPTION
The publish package job failed due to recent changes in the init file that tries to get the version from another module. 

https://github.com/astronomer/airflow-provider-great-expectations/actions/runs/13457867015/job/37605752581

So, to help unblock the release efforts, I am statically copying back the version to init file and we could rework on adjusting the verify tag script to accommodate using version from another module.