### PR TITLE
[BUGFIX] Replace use of add_or_update with explicit get or update

### DIFF
--- a/great_expectations_provider/exceptions/exceptions.py
+++ b/great_expectations_provider/exceptions/exceptions.py
@@ -1,0 +1,4 @@
+class ExistingDataSourceTypeMismatch(Exception):
+    def __init__(self, expected_type: type, actual_type: type, name: str) -> None:
+        message = f"Error getting datasource '{name}'; expected type {expected_type.__name__}, but got {actual_type.__name__}."
+        super().__init__(message)

--- a/great_expectations_provider/operators/validate_dataframe.py
+++ b/great_expectations_provider/operators/validate_dataframe.py
@@ -8,7 +8,9 @@ from great_expectations_provider.common.gx_context_actions import (
     load_data_context,
     run_validation_definition,
 )
-from great_expectations_provider.exceptions.exceptions import ExistingDataSourceTypeMismatch
+from great_expectations_provider.exceptions.exceptions import (
+    ExistingDataSourceTypeMismatch,
+)
 from great_expectations_provider.hooks.gx_cloud import GXCloudHook
 from great_expectations.datasource.fluent import PandasDatasource, SparkDatasource
 

--- a/tests/integration/test_validate_batch_operator.py
+++ b/tests/integration/test_validate_batch_operator.py
@@ -56,6 +56,44 @@ class TestValidateBatchOperator:
 
         assert result["success"] is True
 
+    def test_multiple_runs_with_cloud_context(
+        self,
+        ensure_data_source_cleanup: Callable[[str], None],
+        ensure_suite_cleanup: Callable[[str], None],
+        ensure_validation_definition_cleanup: Callable[[str], None],
+    ) -> None:
+        task_id = f"validate_batch_cloud_integration_test_{rand_name()}"
+        ensure_data_source_cleanup(task_id)
+        ensure_suite_cleanup(task_id)
+        ensure_validation_definition_cleanup(task_id)
+        dataframe = pd.DataFrame({self.COL_NAME: ["a", "b", "c"]})
+        expect = gxe.ExpectColumnValuesToBeInSet(
+            column=self.COL_NAME,
+            value_set=["a", "b", "c", "d", "e"],  # type: ignore[arg-type]
+        )
+        batch_parameters = {"dataframe": dataframe}
+
+        def configure_batch_definition(context: AbstractDataContext) -> BatchDefinition:
+            return (
+                context.data_sources.add_pandas(name=task_id)
+                .add_dataframe_asset(task_id)
+                .add_batch_definition_whole_dataframe(task_id)
+            )
+
+        validate_cloud_batch = GXValidateBatchOperator(
+            task_id=task_id,
+            configure_batch_definition=configure_batch_definition,
+            expect=expect,
+            batch_parameters=batch_parameters,
+            context_type="cloud",
+        )
+
+        result = validate_cloud_batch.execute(context={})
+        assert result["success"] is True
+
+        result = validate_cloud_batch.execute(context={})
+        assert result["success"] is True
+
     def test_file_system_data_source(
         self,
         load_csv_data: Callable[[Path, list[dict]], None],

--- a/tests/unit/test_validate_dataframe_operator.py
+++ b/tests/unit/test_validate_dataframe_operator.py
@@ -8,6 +8,12 @@ from great_expectations import ExpectationSuite
 from great_expectations.core import ExpectationValidationResult
 from great_expectations.expectations import ExpectColumnValuesToBeInSet
 from great_expectations.datasource.fluent import PandasDatasource, SparkDatasource
+from great_expectations.datasource.fluent.pandas_datasource import (
+    DataFrameAsset as PandasDataFrameAsset,
+)
+from great_expectations.datasource.fluent.spark_datasource import (
+    DataFrameAsset as SparkDataFrameAsset,
+)
 from great_expectations.data_context import EphemeralDataContext
 
 from great_expectations_provider.common.constants import USER_AGENT_STR
@@ -16,6 +22,14 @@ from great_expectations_provider.operators.validate_dataframe import (
 )
 
 pytestmark = pytest.mark.unit
+
+
+class MockSparkDataFrame:
+    # Dummy class so we don't have to have pyspark dep in unit tests
+    ...
+
+
+MockSparkDataFrame.__name__ = "DataFrame"
 
 
 class TestValidateDataFrameOperator:
@@ -202,12 +216,185 @@ class TestValidateDataFrameOperator:
             user_agent_str=USER_AGENT_STR,
         )
 
+    def test_pandas_does_not_error_when_no_datasource(
+        self, mock_gx_no_datasource: Mock
+    ) -> None:
+        validate_df = GXValidateDataFrameOperator(
+            task_id="validate_df_success",
+            configure_dataframe=Mock(return_value=Mock(spec=pd.DataFrame)),
+            expect=Mock(),
+            context_type="cloud",
+        )
+
+        # act
+        validate_df.execute(context={})
+
+    def test_pandas_does_not_error_when_no_asset(
+        self, mock_gx_with_pandas_datasource_but_no_asset: Mock
+    ) -> None:
+        validate_df = GXValidateDataFrameOperator(
+            task_id="validate_df_success",
+            configure_dataframe=Mock(return_value=Mock(spec=pd.DataFrame)),
+            expect=Mock(),
+            context_type="cloud",
+        )
+
+        # act
+        validate_df.execute(context={})
+
+    def test_pandas_does_not_error_when_no_batch_definition(
+        self, mock_gx_with_pandas_datasource_but_no_batch_definition: Mock
+    ) -> None:
+        validate_df = GXValidateDataFrameOperator(
+            task_id="validate_df_success",
+            configure_dataframe=Mock(return_value=Mock(spec=pd.DataFrame)),
+            expect=Mock(),
+            context_type="cloud",
+        )
+
+        # act
+        validate_df.execute(context={})
+
+    def test_spark_does_not_error_when_no_datasource(
+        self, mock_gx_no_datasource: Mock
+    ) -> None:
+        validate_df = GXValidateDataFrameOperator(
+            task_id="validate_df_success",
+            configure_dataframe=Mock(return_value=Mock(spec=pd.DataFrame)),
+            expect=Mock(),
+            context_type="cloud",
+        )
+
+        # act
+        validate_df.execute(context={})
+
+    def test_spark_does_not_error_when_no_asset(
+        self, mock_gx_with_spark_datasource_but_no_asset: Mock
+    ) -> None:
+        validate_df = GXValidateDataFrameOperator(
+            task_id="validate_df_success",
+            configure_dataframe=Mock(return_value=MockSparkDataFrame()),
+            expect=Mock(),
+            context_type="cloud",
+        )
+
+        # act
+        validate_df.execute(context={})
+
+    def test_spark_does_not_error_when_no_batch_definition(
+        self, mock_gx_with_spark_datasource_but_no_batch_definition: Mock
+    ) -> None:
+        validate_df = GXValidateDataFrameOperator(
+            task_id="validate_df_success",
+            configure_dataframe=Mock(return_value=MockSparkDataFrame()),
+            expect=Mock(),
+            context_type="cloud",
+        )
+
+        # act
+        validate_df.execute(context={})
+
+    @pytest.fixture
+    def mock_gx_no_datasource(
+        self,
+        mock_gx: Mock,
+    ) -> Mock:
+        mock_datasource = create_autospec(spec=PandasDatasource)
+        mock_datasource.get_asset.side_effect = LookupError
+        mock_context = create_autospec(
+            spec=EphemeralDataContext,
+            data_sources=Mock(get=Mock(side_effect=KeyError)),
+        )
+        mock_gx.get_context.return_value = mock_context
+        return mock_gx
+
     @pytest.fixture
     def mock_gx_with_pandas_datasource(
         self,
         mock_gx: Mock,
     ) -> Mock:
         mock_datasource = create_autospec(spec=PandasDatasource)
+        mock_context = create_autospec(
+            spec=EphemeralDataContext,
+            data_sources=Mock(get=Mock(return_value=mock_datasource)),
+        )
+        mock_gx.get_context.return_value = mock_context
+        return mock_gx
+
+    @pytest.fixture
+    def mock_gx_with_pandas_datasource_but_no_asset(
+        self,
+        mock_gx: Mock,
+    ) -> Mock:
+        mock_datasource = create_autospec(spec=PandasDatasource)
+        mock_datasource.get_asset.side_effect = LookupError
+        mock_context = create_autospec(
+            spec=EphemeralDataContext,
+            data_sources=Mock(get=Mock(return_value=mock_datasource)),
+        )
+        mock_gx.get_context.return_value = mock_context
+        return mock_gx
+
+    @pytest.fixture
+    def mock_gx_with_pandas_datasource_but_no_batch_definition(
+        self,
+        mock_gx: Mock,
+    ) -> Mock:
+        mock_asset = create_autospec(
+            spec=PandasDataFrameAsset,
+            get_batch_definition=Mock(side_effect=KeyError),
+        )
+        mock_datasource = create_autospec(
+            spec=PandasDatasource,
+            get_asset=Mock(return_value=mock_asset),
+        )
+        mock_context = create_autospec(
+            spec=EphemeralDataContext,
+            data_sources=Mock(get=Mock(return_value=mock_datasource)),
+        )
+        mock_gx.get_context.return_value = mock_context
+        return mock_gx
+
+    @pytest.fixture
+    def mock_gx_with_spark_datasource(
+        self,
+        mock_gx: Mock,
+    ) -> Mock:
+        mock_datasource = create_autospec(spec=SparkDatasource)
+        mock_context = create_autospec(
+            spec=EphemeralDataContext,
+            data_sources=Mock(get=Mock(return_value=mock_datasource)),
+        )
+        mock_gx.get_context.return_value = mock_context
+        return mock_gx
+
+    @pytest.fixture
+    def mock_gx_with_spark_datasource_but_no_asset(
+        self,
+        mock_gx: Mock,
+    ) -> Mock:
+        mock_datasource = create_autospec(spec=SparkDatasource)
+        mock_datasource.get_asset.side_effect = LookupError
+        mock_context = create_autospec(
+            spec=EphemeralDataContext,
+            data_sources=Mock(get=Mock(return_value=mock_datasource)),
+        )
+        mock_gx.get_context.return_value = mock_context
+        return mock_gx
+
+    @pytest.fixture
+    def mock_gx_with_spark_datasource_but_no_batch_definition(
+        self,
+        mock_gx: Mock,
+    ) -> Mock:
+        mock_asset = create_autospec(
+            spec=SparkDataFrameAsset,
+            get_batch_definition=Mock(side_effect=KeyError),
+        )
+        mock_datasource = create_autospec(
+            spec=SparkDatasource,
+            get_asset=Mock(return_value=mock_asset),
+        )
         mock_context = create_autospec(
             spec=EphemeralDataContext,
             data_sources=Mock(get=Mock(return_value=mock_datasource)),


### PR DESCRIPTION
This addresses a bug in which all calls to `data_sources.add_or_update_*` after the first will fail in cloud contexts. It is a workaround for existing bugs in great_expectations cloud.