### PR TITLE
Mention Committers in the documentation

### DIFF
--- a/docs/contributing/contributors.md
+++ b/docs/contributing/contributors.md
@@ -3,6 +3,11 @@
 There are different ways people can contribute to the Great Expectations Airflow Provider.
 Learn more about the project [contributors roles](/docs/contributing/contributor-roles.md).
 
+## Committers
+
+* Pankaj Koti ([@pankajkoti](https://github.com/pankajkoti))
+* Joshua Stauffer ([@joshua-stauffer](https://github.com/joshua-stauffer))
+* Tyler Hoffman ([@tyler-hoffman](https://github.com/tyler-hoffman))
 
 ## Contributors
 


### PR DESCRIPTION
This PR adds the following contributors as committers as per the docs mentioned at https://github.com/astronomer/airflow-provider-great-expectations/blob/main/docs/contributing/contributor-roles.md#committers:

* Pankaj Koti ([@pankajkoti](https://github.com/pankajkoti))
* Joshua Stauffer ([@joshua-stauffer](https://github.com/joshua-stauffer))
* Tyler Hoffman ([@tyler-hoffman](https://github.com/tyler-hoffman))