### PR TITLE
Use absolute GitHub URLs in the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 A set of Airflow operators for [Great Expectations](https://greatexpectations.io/), a framework for describing data using expressive tests and then validating that the data meets test criteria.
 
-Visit the [docs](/docs/index.md) to learn more about the Great Expectations Airflow Provider:
+Visit the [docs](https://github.com/astronomer/airflow-provider-great-expectations/blob/main/docs/index.md) to learn more about the Great Expectations Airflow Provider:
 
-- [Getting started](/docs/getting-started.md)
-- [Examples](/docs/examples.md)
-- [Migration guide](/docs/migration-guide.md)
+- [Getting started](https://github.com/astronomer/airflow-provider-great-expectations/blob/main/docs/getting-started.md)
+- [Examples](https://github.com/astronomer/airflow-provider-great-expectations/blob/main/docs/examples.md)
+- [Migration guide](https://github.com/astronomer/airflow-provider-great-expectations/blob/main/docs/migration-guide.md)
 - Contributing
-   - [Code of conduct](/docs/contributing/code-of-conduct.md)
-   - [Contributors](/docs/contributing/contributors.md)
-   - [Contributing guide](/docs/contributing/contributing-guide.md)
-   - [Contributor roles](/docs/contributing/contributor-roles.md)
+   - [Code of conduct](https://github.com/astronomer/airflow-provider-great-expectations/blob/main/docs/contributing/code-of-conduct.md)
+   - [Contributors](https://github.com/astronomer/airflow-provider-great-expectations/blob/main/docs/contributing/contributors.md)
+   - [Contributing guide](https://github.com/astronomer/airflow-provider-great-expectations/blob/main/docs/contributing/contributing-guide.md)
+   - [Contributor roles](https://github.com/astronomer/airflow-provider-great-expectations/blob/main/docs/contributing/contributor-roles.md)

--- a/docs/contributing/contributing-guide.md
+++ b/docs/contributing/contributing-guide.md
@@ -2,9 +2,9 @@
 
 All contributions, bug reports, bug fixes, documentation improvements, and enhancements are welcome.
 
-All contributors and maintainers to this project should abide by the [Contributor Code of Conduct](/docs/contributing/code-of-conduct.md).
+All contributors and maintainers to this project should abide by the [Contributor Code of Conduct](https://github.com/astronomer/airflow-provider-great-expectations/blob/main/docs/contributing/code-of-conduct.md).
 
-Learn more about the contributors' roles in the [Roles](/docs/contributing/contributor-roles.md) page.
+Learn more about the contributors' roles in the [Roles](https://github.com/astronomer/airflow-provider-great-expectations/blob/main/docs/contributing/contributor-roles.md) page.
 
 This document describes how to contribute to the Great Expectations Airflow Provider, covering:
 

--- a/docs/contributing/contributor-roles.md
+++ b/docs/contributing/contributor-roles.md
@@ -3,7 +3,7 @@
 Contributors are welcome and are greatly appreciated! Every little bit helps, and we give credit to them.
 
 This document aims to explain the current roles in the Great Expectations Airflow Provider project.
-For more information, check the [contributing guide](/docs/contributing/contributing-guide.md).
+For more information, check the [contributing guide](https://github.com/astronomer/airflow-provider-great-expectations/blob/main/docs/contributing/contributing-guide.md).
 
 ## Contributors
 
@@ -24,7 +24,7 @@ Contributors are responsible for:
 Committers are community members with write access to the [Great Expectations Airflow Provider GitHub repository](https://github.com/astronomer/airflow-provider-great-expectations).
 They can modify the code and the documentation and accept others' contributions to the repo.
 
-Check [contributors](/docs/contributing/contributors.md) for the official list of Great Expectations Airflow Provider committers.
+Check [contributors](https://github.com/astronomer/airflow-provider-great-expectations/blob/main/docs/contributing/contributors.md) for the official list of Great Expectations Airflow Provider committers.
 
 Committers have the same responsibilities as standard contributors and also perform the following actions:
 
@@ -42,7 +42,7 @@ General prerequisites that we look for in all candidates:
 1. Consistent contribution over the last few months
 2. Visibility on discussions on the Slack channel or GitHub issues/discussions
 3. Contributes to community health and project's sustainability for the long term
-4. Understands the project's [contributors' guidelines](/docs/contributing/contributing-guide.md)
+4. Understands the project's [contributors' guidelines](https://github.com/astronomer/airflow-provider-great-expectations/blob/main/docs/contributing/contributing-guide.md)
 
 Astronomer is responsible and accountable for releasing new versions of the Great Expectations Airflow Provider in [PyPI](https://pypi.org/project/airflow-provider-great-expectations/), following the [milestones](https://github.com/astronomer/airflow-provider-great-expectations/milestones).
 Astronomer has the right to grant and revoke write access permissions to the project's official repository for any reason it sees fit.

--- a/docs/contributing/contributors.md
+++ b/docs/contributing/contributors.md
@@ -1,7 +1,7 @@
 # Contributors
 
 There are different ways people can contribute to the Great Expectations Airflow Provider.
-Learn more about the project [contributors roles](/docs/contributing/contributor-roles.md).
+Learn more about the project [contributors roles](https://github.com/astronomer/airflow-provider-great-expectations/blob/main/docs/contributing/contributor-roles.md).
 
 
 ## Contributors

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,15 +4,15 @@ With the Great Expectations Airflow Provider, you can validate data directly fro
 
 ## Getting started
 
-If you're new to the Great Expectations Airflow Provider, check out the [getting started](/docs/getting-started.md) page for guidance on which options best fit your use case and instructions on how to use them.
+If you're new to the Great Expectations Airflow Provider, check out the [getting started](https://github.com/astronomer/airflow-provider-great-expectations/blob/main/docs/getting-started.md) page for guidance on which options best fit your use case and instructions on how to use them.
 
 ## Examples
 
-Explore [examples](/docs/examples.md) of end-to-end configuration and usage.
+Explore [examples](https://github.com/astronomer/airflow-provider-great-expectations/blob/main/docs/examples.md) of end-to-end configuration and usage.
 
 ## Migration Guide
 
-If you used the legacy `GreatExpectationsOperator`, follow the [migration guide](/docs/migration-guide.md) to update your configuration to use one of the new Operators.
+If you used the legacy `GreatExpectationsOperator`, follow the [migration guide](https://github.com/astronomer/airflow-provider-great-expectations/blob/main/docs/migration-guide.md) to update your configuration to use one of the new Operators.
 
 ## Getting help
 
@@ -22,7 +22,7 @@ Report bugs, questions, and feature requests in our [ticket tracker](https://git
 
 The Great Expectations Airflow Provider is an open-source project. Learn about its development process and about how you can contribute:
 
-- [Contributing guide](/docs/contributing/contributing-guide.md)
+- [Contributing guide](https://github.com/astronomer/airflow-provider-great-expectations/blob/main/docs/contributing/contributing-guide.md)
 - [GitHub repository](https://github.com/astronomer/airflow-provider-great-expectations)
 
 ## License

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -11,13 +11,13 @@ Here is an overview of key differences between versions:
 | Data Contexts | File | Ephemeral<br>Cloud<br>File (`GXValidateCheckpointOperator` only) |
 | Response handling | By default, any Expectation failure raises an `AirflowException`. To override this behavior and continue running the pipeline even if tests fail, you can set the `fail_task_on_validation_failure` flag to `False`. | Regardless of Expectation failure or success, a Validation Result is made available to subsequent tasks, which can decide what to do with the result. |
 
-For guidance on which Operator and Data Context best fit your needs, see [Operator use cases](/docs/getting-started.md/#operator-use-cases). Note that while File Data Contexts are still supported with `GXValidateCheckpointOperator`, they require extra configuration and can be challenging to use when Airflow is running in a distributed environment. Most uses of the legacy `GreatExpectationsOperator` can now be satisfied with an Ephemeral or Cloud Data Context with either the `GXValidateDataFrameOperator` or the `GXValidateBatchOperator` to minimize configuration.
+For guidance on which Operator and Data Context best fit your needs, see [Operator use cases](https://github.com/astronomer/airflow-provider-great-expectations/blob/main/docs/getting-started.md/#operator-use-cases). Note that while File Data Contexts are still supported with `GXValidateCheckpointOperator`, they require extra configuration and can be challenging to use when Airflow is running in a distributed environment. Most uses of the legacy `GreatExpectationsOperator` can now be satisfied with an Ephemeral or Cloud Data Context with either the `GXValidateDataFrameOperator` or the `GXValidateBatchOperator` to minimize configuration.
 
 ## Switch to the new Data Frame or Batch Operator (recommended)
 
 The configuration options for the new `GXValidateDataFrameOperator` and `GXValidateBatchOperator` are streamlined compared to the old `GreatExpectationsOperator`. Switching to one of these doesn’t involve translating existing configuration into new syntax line for line but rather paring back to a more minimal configuration.
 
-- See [getting started](/docs/getting-started.md) for an overview of required configuration.
+- See [getting started](https://github.com/astronomer/airflow-provider-great-expectations/blob/main/docs/getting-started.md) for an overview of required configuration.
 - Explore [examples](https://github.com/astronomer/airflow-provider-great-expectations/tree/docs/great_expectations_provider/example_dags) of end-to-end configuration and usage.
 
 ## Migrate to the new Checkpoint Operator
@@ -72,7 +72,7 @@ If you want to update your existing `GreatExpectationsOperator` configuration to
         return context.checkpoints.get(name="<YOUR CHECKPOINT NAME>")
     ```
 
-- See [getting started](/docs/getting-started.md) for more information about required and optional configuration.
+- See [getting started](https://github.com/astronomer/airflow-provider-great-expectations/blob/main/docs/getting-started.md) for more information about required and optional configuration.
 - Explore [examples](https://github.com/astronomer/airflow-provider-great-expectations/tree/docs/great_expectations_provider/example_dags) of end-to-end configuration and usage.
 
 


### PR DESCRIPTION
As we continue working on [Issue #181](https://github.com/astronomer/airflow-provider-great-expectations/issues/181), it would be beneficial to fix the broken URLs currently present on [PyPI](https://pypi.org/project/airflow-provider-great-expectations/1.0.0a1/). This ensures that the URLs function correctly in the upcoming alpha release, in case we are unable to complete Issue #181 in time.

Closes: #177