### PR TITLE
Upgrade pre-commit hook version as being attempted by pre-commit bot in PR #189

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
       - id: remove-tabs
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.0
+    rev: v0.11.2
     hooks:
       - id: ruff
         args: [ --fix ]


### PR DESCRIPTION
Apparently PR #189 was created earlier when we had the setup.cfg file and looks like it is picking up invalid project configuration to run tests in CI and hence failing. I have created a this new PR using a branch cut from latest main that replicates the upgrade being attempted in #189 .